### PR TITLE
Standardize fund management fee to 20% for all future AGL shipment financing contracts

### DIFF
--- a/standardize-fund-management-fee-to-20-for-all-future-agl-shipment-financing-contracts.md
+++ b/standardize-fund-management-fee-to-20-for-all-future-agl-shipment-financing-contracts.md
@@ -1,0 +1,52 @@
+[PROPOSAL CREATION]
+- Type: governance
+- Title: Standardize fund management fee to 20% for all future AGL shipment financing contracts
+- Content: ## Summary
+
+Proposal to **standardize the fund management fee to 20%** for all **future** AGL **shipment financing** contracts. Operational funds ledgers (which invest in other AGLs) remain at **no fee** to avoid double-charging, per existing policy.
+
+---
+
+## Background
+
+- **Shipment financing ledger:** Per-shipment AGL contract (e.g. AGL1, AGL2) for a direct cacao shipment with physical collateral. The DAO provides fund management, operations, and reporting.
+- **Operational funds ledger:** Fund that invests in other AGLs; underlying AGLs already charge 20%, so the operational fund layer does **not** charge an additional fee.
+- This proposal applies only to **shipment financing** ledgers. Fee structures for those have varied; standardizing at 20% for future shipment contracts gives one clear rate.
+
+---
+
+## Proposed change
+
+- **Shipment financing (future AGL contracts):** **20%** fund management fee for all **new** AGL contracts that are **shipment financing** (direct shipment with physical collateral).
+- **Operational funds (unchanged):** No 20% fee at the operational fund level when the fund invests in other AGLs. No double-charging.
+- **Scope:** Applies only to **future** shipment financing AGL contracts. Existing contracts stay on their current terms unless amended by mutual agreement.
+
+---
+
+## Rationale
+
+1. **Industry alignment** ? 20% is familiar in VC and hedge fund management fees.
+2. **Clarity** ? One rate for new shipment financing deals; operational funds explicitly excluded.
+3. **Consistency with syndicate policy** ? Aligns with Shipment financing = 20% fee; operational fund = no fee (SYNDICATE_AGREEMENTS / context precedence).
+4. **Transparency** ? Voted policy so partners and members know the default terms.
+
+---
+
+## Implementation
+
+- Once passed: reflect the 20% standard for **shipment financing** in new AGL contract templates and in governance/operations docs. Operational fund agreements continue to omit the 20% fee. Existing contracts unchanged unless separately revised.
+
+---
+
+## Request
+
+DAO members are asked to vote **YES** to adopt the 20% standard fund management fee for all future AGL **shipment financing** contracts (operational funds remain no fee), or **NO** to reject.
+--------
+
+My Digital Signature: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA54jNZdN4xkaPDI9TB/RwuicbbUMvttOWSTVRfvZxiHWeIoqTHRz2WJdoGsuW9rz9QPbpz6T9zQZu3RNzsSF216U3aCd89R2g7qhOMh9VC+7+sNJnI6H4qPPKFbndxQD8262Q+zqYQR6r0k89mud1sYbla/DCtKAcGZsALihVyl8tF2v1rUzfPU9FHpi5ow2kOEpVxnhe6xEY1HDU/zuFRt707WzkG1zit4AWEBXyBd3YLyinPNAb2aBA6dSPnPAQ4aB46Dtis3p5DgkLeO7E4gh/E0BqViDkkB1tLy1dgy9Kjv+5zxo1yTxkBKACjqqo69Q0VrUfkXgegWmXBAu04wIDAQAB
+
+Request Transaction ID: d/mgSx75VukfeX0FPFtZA0mv8jOEJ9PoSzkaMsqYPErZVlq1TqRhVPgUqjqaqGqaFb5BsO3vS2wXXooSsUWiUJfnagdbocCQm4jNpV50OdSnpXbMEGA6dgP6uJX5oYJk9dvLRRgCLHDsCp3yPAjyf9pWHvDy+Z4eHv7D1qvrrJg3zres+v04r6Tn82gLS4pVkPm9QfKF7YuEb7Xn4Pboax1Id41uPPdTzlkaJVQIOz5+Izfka9/QdaJDo8XxFe4hd7tD6dTB00kokCnruTFGXk0ROVscjBmXbv0A8Jmnm9F52rj00hkIF5PgC+hVrBvJ5cNMup9XsG7Hku/UecO3pg==
+
+This submission was generated using https://dapp.truesight.me/create_proposal.html
+
+Verify submission here: https://dapp.truesight.me/verify_request.html


### PR DESCRIPTION
[PROPOSAL CREATION]
- Type: governance
- Title: Standardize fund management fee to 20% for all future AGL shipment financing contracts
- Content: ## Summary

Proposal to **standardize the fund management fee to 20%** for all **future** AGL **shipment financing** contracts. Operational funds ledgers (which invest in other AGLs) remain at **no fee** to avoid double-charging, per existing policy.

---

## Background

- **Shipment financing ledger:** Per-shipment AGL contract (e.g. AGL1, AGL2) for a direct cacao shipment with physical collateral. The DAO provides fund management, operations, and reporting.
- **Operational funds ledger:** Fund that invests in other AGLs; underlying AGLs already charge 20%, so the operational fund layer does **not** charge an additional fee.
- This proposal applies only to **shipment financing** ledgers. Fee structures for those have varied; standardizing at 20% for future shipment contracts gives one clear rate.

---

## Proposed change

- **Shipment financing (future AGL contracts):** **20%** fund management fee for all **new** AGL contracts that are **shipment financing** (direct shipment with physical collateral).
- **Operational funds (unchanged):** No 20% fee at the operational fund level when the fund invests in other AGLs. No double-charging.
- **Scope:** Applies only to **future** shipment financing AGL contracts. Existing contracts stay on their current terms unless amended by mutual agreement.

---

## Rationale

1. **Industry alignment** — 20% is familiar in VC and hedge fund management fees.
2. **Clarity** — One rate for new shipment financing deals; operational funds explicitly excluded.
3. **Consistency with syndicate policy** — Aligns with Shipment financing = 20% fee; operational fund = no fee (SYNDICATE_AGREEMENTS / context precedence).
4. **Transparency** — Voted policy so partners and members know the default terms.

---

## Implementation

- Once passed: reflect the 20% standard for **shipment financing** in new AGL contract templates and in governance/operations docs. Operational fund agreements continue to omit the 20% fee. Existing contracts unchanged unless separately revised.

---

## Request

DAO members are asked to vote **YES** to adopt the 20% standard fund management fee for all future AGL **shipment financing** contracts (operational funds remain no fee), or **NO** to reject.
--------

My Digital Signature: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA54jNZdN4xkaPDI9TB/RwuicbbUMvttOWSTVRfvZxiHWeIoqTHRz2WJdoGsuW9rz9QPbpz6T9zQZu3RNzsSF216U3aCd89R2g7qhOMh9VC+7+sNJnI6H4qPPKFbndxQD8262Q+zqYQR6r0k89mud1sYbla/DCtKAcGZsALihVyl8tF2v1rUzfPU9FHpi5ow2kOEpVxnhe6xEY1HDU/zuFRt707WzkG1zit4AWEBXyBd3YLyinPNAb2aBA6dSPnPAQ4aB46Dtis3p5DgkLeO7E4gh/E0BqViDkkB1tLy1dgy9Kjv+5zxo1yTxkBKACjqqo69Q0VrUfkXgegWmXBAu04wIDAQAB

Request Transaction ID: d/mgSx75VukfeX0FPFtZA0mv8jOEJ9PoSzkaMsqYPErZVlq1TqRhVPgUqjqaqGqaFb5BsO3vS2wXXooSsUWiUJfnagdbocCQm4jNpV50OdSnpXbMEGA6dgP6uJX5oYJk9dvLRRgCLHDsCp3yPAjyf9pWHvDy+Z4eHv7D1qvrrJg3zres+v04r6Tn82gLS4pVkPm9QfKF7YuEb7Xn4Pboax1Id41uPPdTzlkaJVQIOz5+Izfka9/QdaJDo8XxFe4hd7tD6dTB00kokCnruTFGXk0ROVscjBmXbv0A8Jmnm9F52rj00hkIF5PgC+hVrBvJ5cNMup9XsG7Hku/UecO3pg==

This submission was generated using https://dapp.truesight.me/create_proposal.html

Verify submission here: https://dapp.truesight.me/verify_request.html